### PR TITLE
Add all supported Python versions as classifiers

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,9 @@ classifiers =
     Operating System :: Microsoft :: Windows
     Operating System :: POSIX :: Linux
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Games/Entertainment
 project_urls =
 #    Documentation =


### PR DESCRIPTION
We should add all supported Python versions as classifiers to correctly support PyPI