### PR TITLE
Reduce CI workload

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -2,6 +2,10 @@ name: Linting Python code (flake8)
 
 on:
   push:
+    branches:
+    - main
+    - develop
+    - releases/**
   pull_request:
     branches:
     - main

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8']
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8']
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -2,6 +2,10 @@ name: Static typechecking (mypy)
 
 on:
   push:
+    branches:
+    - main
+    - develop
+    - releases/**
   pull_request:
     branches:
     - main

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8']
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,6 +2,10 @@ name: Python linting (pylint)
 
 on:
   push:
+    branches:
+    - main
+    - develop
+    - releases/**
   pull_request:
     branches:
     - main

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,6 +2,10 @@ name: Python tests (pytest)
 
 on:
   push:
+    branches:
+    - main
+    - develop
+    - releases/**
   pull_request:
     branches:
     - main

--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/juhannc/beerpong/main.svg)](https://results.pre-commit.ci/latest/github/juhannc/beerpong/main)
 [![codecov](https://codecov.io/gh/juhannc/beerpong/branch/main/graph/badge.svg)](https://codecov.io/gh/juhannc/beerpong)
 [![Maintainability](https://api.codeclimate.com/v1/badges/ba14c01e22ad0343af8c/maintainability)](https://codeclimate.com/github/juhannc/beerpong/maintainability)
+[![Code style](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/juhannc/beerpong)
 
-[![Pypi Status](https://badge.fury.io/py/beerpong.svg)](https://badge.fury.io/py/beerpong)
+[![PyPI Status](https://badge.fury.io/py/beerpong.svg)](https://badge.fury.io/py/beerpong)
+[![Downloads](https://static.pepy.tech/badge/beerpong)](https://pepy.tech/project/beerpong)
 
 Bracketing tool with beerpong in mind
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ classifiers =
     Operating System :: Microsoft :: Windows
     Operating System :: POSIX :: Linux
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.12
     Topic :: Games/Entertainment
 project_urls =
 #    Documentation =


### PR DESCRIPTION
To save on my free CI minutes, I reduced the number of jobs.
Static code checks are now only performed against the minimum Python version, aka 3.8, but the tests add support for 3.12