### PR TITLE
Update classifiers to match license (#2, 6a283fc)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,13 +7,13 @@ long_description_content_type = text/markdown; charset=UTF-8
 url = https://github.com/juhannc/beerpong.git
 author = Johann Christensen
 author_email = johannchristensen@outlook.de
-license = MIT
+license = GPLv3
 license_files = LICENSE
 classifiers =
     Development Status :: 4 - Beta
     Environment :: X11 Applications :: Qt
     Intended Audience :: End Users/Desktop
-    License :: OSI Approved :: MIT License
+    License :: OSI Approved :: GNU General Public License v3 (GPLv3)
     Natural Language :: English
     Operating System :: MacOS
     Operating System :: Microsoft :: Windows


### PR DESCRIPTION
In #2 we changed the license to GPLv3 (6a283fc) but never changed the classifiers in the `setup.cfg` file